### PR TITLE
chore: ci changes and main switch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,9 @@
 version: 2.1
 
-orbs:
-  node: artsy/node@1.0.0
-
 jobs:
   build:
-    executor: node/build
+    docker:
+      - image: cimg/node:14.18.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - build
   build:

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ A new version of *${process.env.PACKAGE_NAME}* was just published! (${latestVers
 console.log("CIRCLE_BRANCH", process.env.CIRCLE_BRANCH)
 console.log("NODE_ENV", process.env.NODE_ENV)
 if (
-  process.env.CIRCLE_BRANCH === "master" ||
+  process.env.CIRCLE_BRANCH === "main" ||
   process.env.NODE_ENV === "development"
 ) {
   run()


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4129

This CL change CI to use next-gen convenience node image instead of artsy/node and adds couple edits following master -> main switch.